### PR TITLE
Add the diamond generation back to OreGeneration.addVanillaStuff

### DIFF
--- a/src/main/java/waylanderou/almostalltheores/world/biome/OreGeneration.java
+++ b/src/main/java/waylanderou/almostalltheores/world/biome/OreGeneration.java
@@ -823,6 +823,10 @@ public class OreGeneration {
 			if(!AatoConfig.blacklistLapisOre.get().contains(biome.getRegistryName().toString()))
 				biome.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, Feature.ORE.withConfiguration(new OreFeatureConfig(OreFeatureConfig.FillerBlockType.NATURAL_STONE, Blocks.LAPIS_ORE.getDefaultState(), AatoConfig.VeinSizeLapis.get())).func_227228_a_(Placement.COUNT_DEPTH_AVERAGE.func_227446_a_(new DepthAverageConfig(AatoConfig.VeinsPerChunkLapis.get(), AatoConfig.DepthAverageLapis.get(), AatoConfig.DepthAverageLapis.get()))));
 		}
+		if(AatoConfig.enableDiamond.get()) {
+			if(!AatoConfig.blacklistDiamondOre.get().contains(biome.getRegistryName().toString()))
+				biome.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, Feature.ORE.withConfiguration(new OreFeatureConfig(OreFeatureConfig.FillerBlockType.NATURAL_STONE, Blocks.DIAMOND_ORE.getDefaultState(), AatoConfig.VeinSizeDiamond.get())).func_227228_a_(Placement.COUNT_RANGE.func_227446_a_(new CountRangeConfig(AatoConfig.VeinsPerChunkDiamond.get(), AatoConfig.MinHeightDiamond.get(), 0, AatoConfig.MaxHeightDiamond.get()))));
+		}
 		if(AatoConfig.enableDirt.get()) {
 			biome.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, Feature.ORE.withConfiguration(new OreFeatureConfig(OreFeatureConfig.FillerBlockType.NATURAL_STONE, Blocks.DIRT.getDefaultState(), AatoConfig.VeinSizeDirt.get())).func_227228_a_(Placement.COUNT_RANGE.func_227446_a_(new CountRangeConfig(AatoConfig.VeinsPerChunkDirt.get(), AatoConfig.MinHeightDirt.get(), 0,AatoConfig.MaxHeightDirt.get()))));
 		}


### PR DESCRIPTION
Looks like this got removed from "Vanilla stuff" in your 3.0.1.1 update. PR adds it back in. 

Not sure if there are other repercussions involved, but this should at least let diamond ore spawn again.

Edit: I would make PRs to merge this commit to the other versions but I'm not sure how to do so with your branching structure. Sorry about that.